### PR TITLE
Fix picture source MIME type prefix

### DIFF
--- a/Classes/Domain/Model/ImageSource.php
+++ b/Classes/Domain/Model/ImageSource.php
@@ -149,6 +149,19 @@ class ImageSource implements
         return $this->format;
     }
 
+    public function getMimeType(): ?string
+    {
+        if ($this->format !== '') {
+            return match (strtolower($this->format)) {
+                'jpg', 'jpeg' => 'image/jpeg',
+                'svg' => 'image/svg+xml',
+                default => 'image/' . strtolower($this->format),
+            };
+        }
+
+        return $this->originalImage?->getFile()?->getProperties()['mime_type'] ?? null;
+    }
+
     public function setFormat(string $format): self
     {
         $this->format = $format;

--- a/Resources/Private/Components/Picture/Source/Source.html
+++ b/Resources/Private/Components/Picture/Source/Source.html
@@ -32,7 +32,7 @@
             srcset="{srcset}"
             sizes="{sizes}"
             media="{media}"
-            type="image/{croppedImage.format}"
+            type="{croppedImage.originalImage.file.properties.mime_type}"
         />
         <f:if condition="{preload}">
             <f:asset.css

--- a/Resources/Private/Components/Picture/Source/Source.html
+++ b/Resources/Private/Components/Picture/Source/Source.html
@@ -32,7 +32,7 @@
             srcset="{srcset}"
             sizes="{sizes}"
             media="{media}"
-            type="{croppedImage.originalImage.file.properties.mime_type}"
+            type="{croppedImage.mimeType}"
         />
         <f:if condition="{preload}">
             <f:asset.css

--- a/Resources/Private/Components/Picture/Source/Source.html
+++ b/Resources/Private/Components/Picture/Source/Source.html
@@ -32,7 +32,7 @@
             srcset="{srcset}"
             sizes="{sizes}"
             media="{media}"
-            type="{croppedImage.format}"
+            type="image/{croppedImage.format}"
         />
         <f:if condition="{preload}">
             <f:asset.css


### PR DESCRIPTION
## What
Update the Picture Source component so the generated <source> type attribute uses `image/{croppedImage.format}` instead of the raw format value.

## Why
The `type` attribute on `<source>` should contain a valid MIME type. Prefixing it with `image/` makes the markup standards-compliant and helps browsers evaluate the source correctly during responsive image selection.