### PR TITLE
Add a dedicated class for the picture wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ We use the public namespace from fluid-components.
 ```
 
 ### Pictures
+Use `pictureClass` for the outer `<picture>` element; `class` still applies to the fallback `<img>`.
+
 ```html
 <fc:picture
     src="{originalImage: {fileUid: 5}, srcset: \'400,800,1200\'}"
@@ -54,6 +56,8 @@ We use the public namespace from fluid-components.
     title="Title text"
     lazyload="true"
     preload="true"
+    pictureClass="my-picture"
+    class="my-image"
 />
 ```
 

--- a/Resources/Private/Components/Picture/Picture.html
+++ b/Resources/Private/Components/Picture/Picture.html
@@ -10,6 +10,7 @@
     <fc:param name="sources" type="Sitegeist\MediaComponents\Domain\Model\ImageSource[]" />
     <fc:param name="alt" type="string" optional="1" />
     <fc:param name="title" type="string" optional="1" />
+    <fc:param name="pictureClass" type="string" optional="1" />
 
     <f:comment><!-- Scaling --></f:comment>
     <fc:param name="height" type="integer" optional="1" />
@@ -21,7 +22,7 @@
     <fc:param name="preload" type="boolean" optional="1" />
 
     <fc:renderer>
-        <ft:picture :spaceless="1">
+        <ft:picture class="{pictureClass}" :spaceless="1">
             <f:for each="{sources}" as="source">
                 <fc:picture.source
                     src="{f:if(condition: source.originalImage, then: source, else: src)}"

--- a/Tests/Functional/PictureComponentTest.php
+++ b/Tests/Functional/PictureComponentTest.php
@@ -30,6 +30,22 @@ class PictureComponentTest extends AbstractComponentTestCase
                     lazyload="true"
                     preload="true"
                 />'
+            ],
+            'Picture and image classes provided' => [
+                '<picture class="my-picture"><source srcset="fileadmin/_processed_/3/8/csm_image_a371cde464.png 1000w, fileadmin/_processed_/3/8/csm_image_a81f0ca29d.png 1200w, fileadmin/_processed_/3/8/csm_image_1bd5b4a34a.png 1400w, fileadmin/_processed_/3/8/csm_image_08822e2e11.png 1600w, fileadmin/_processed_/3/8/csm_image_a9d09d86a2.png 1800w, fileadmin/_processed_/3/8/csm_image_88e4340e66.png 2000w" /><img src="fileadmin/_processed_/3/8/csm_image_a79b428830.png" srcset="fileadmin/_processed_/3/8/csm_image_f221e776d0.png 400w, fileadmin/_processed_/3/8/csm_image_48d2565927.png 800w, fileadmin/_processed_/3/8/csm_image_a81f0ca29d.png 1200w" height="100" width="100" alt="Alt text" title="Title text" loading="lazy" class="my-image" /></picture>',
+                '<fc:picture
+                    src="{originalImage: {fileUid: 5}, srcset: \'400,800,1200\'}"
+                    sources="{desktop: {originalImage: {fileUid: 5}, srcset: \'1000, 1200, 1400, 1600, 1800, 2000\'}}"
+                    width="500"
+                    height="100"
+                    maxDimensions="true"
+                    alt="Alt text"
+                    title="Title text"
+                    lazyload="true"
+                    preload="true"
+                    pictureClass="my-picture"
+                    class="my-image"
+                />'
             ]
         ];
     }


### PR DESCRIPTION
This adds an optional pictureClass argument to `fc:picture` so the outer `<picture>` element can be styled independently from the fallback `<img>`.

**What changed:**
- Added pictureClass to the Picture component API.
- Forwarded pictureClass to the outer <ft:picture> wrapper.
- Kept the existing class argument on <fc:image> for the fallback <img>.
- Added functional test coverage for both wrapper and image classes.
- Updated the README example to show the new usage.

**Testing:**
- Functional tests were updated, but I could not run the TYPO3 Docker-based suite in this sandbox.